### PR TITLE
Port create-yourself skill to Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/Python-3.9%2B-blue.svg)](https://python.org)
-[![Claude Code](https://img.shields.io/badge/Claude%20Code-Skill-blueviolet)](https://claude.ai/code)
+[![Codex](https://img.shields.io/badge/Codex-Skill-blueviolet)](https://openai.com/codex/)
 [![AgentSkills](https://img.shields.io/badge/AgentSkills-Standard-green)](https://agentskills.io)
 
 <br>
@@ -32,18 +32,16 @@
 
 ## 安装
 
-### Claude Code
+### Codex
 
-> **重要**：Claude Code 从 **git 仓库根目录** 的 `.claude/skills/` 查找 skill。请在正确的位置执行。
+> **重要**：Codex 默认从 `$CODEX_HOME/skills` 查找 skill；如果 `CODEX_HOME` 未设置，则使用 `~/.codex/skills/`。推荐直接安装到全局技能目录。
 
 ```bash
-# 安装到当前项目（在 git 仓库根目录执行）
-mkdir -p .claude/skills
-git clone https://github.com/notdog1998/yourself-skill .claude/skills/create-yourself
-
-# 或安装到全局（所有项目都能用）
-git clone https://github.com/notdog1998/yourself-skill ~/.claude/skills/create-yourself
+# 全局安装（推荐）
+git clone https://github.com/notdog1998/yourself-skill ~/.codex/skills/create-yourself
 ```
+
+生成的自我 Skill 会写入 `~/.codex/skills/create-yourself/selves/`，并可直接作为嵌套 skill 被 Codex 识别。
 
 ### 依赖（可选）
 
@@ -55,26 +53,25 @@ pip install -r requirements.txt
 
 ## 使用
 
-在 Claude Code 中输入：
+在 Codex 中输入：
 
 ```
-/create-yourself
+$create-yourself
 ```
 
 按提示输入你的代号、基本信息、自我画像，然后选择数据来源。所有字段均可跳过，仅凭描述也能生成。
 
-完成后用 `/{slug}` 调用该自我 Skill，开始对话。
+完成后用 `$slug` 调用该自我 Skill，开始对话。
 
-### 管理命令
+### 管理方式
 
-| 命令 | 说明 |
+| 输入 | 说明 |
 |------|------|
-| `/list-selves` | 列出所有自我 Skill |
-| `/{slug}` | 调用完整 Skill（像你一样思考和说话） |
-| `/{slug}-self` | 自我档案模式（帮你回忆和分析自己） |
-| `/{slug}-persona` | 人格模式（仅性格和表达风格） |
-| `/yourself-rollback {slug} {version}` | 回滚到历史版本 |
-| `/delete-yourself {slug}` | 删除 |
+| `$create-yourself 列出已有 self skills` | 列出所有自我 Skill |
+| `$slug` | 调用完整 Skill（像你一样思考和说话） |
+| `$create-yourself 给 {slug} 追加文件` | 追加新材料并更新 |
+| `$create-yourself 回滚 {slug} 到 {version}` | 回滚到历史版本 |
+| `$create-yourself 删除 {slug}` | 删除 |
 
 ---
 
@@ -224,7 +221,7 @@ create-yourself/
 
 自己.skill 在此基础上将视角内转：对象不再是他人，而是你自己。致敬两位原作者的创意和开源精神。
 
-本项目遵循 [AgentSkills](https://agentskills.io) 开放标准，兼容 Claude Code 和 OpenClaw。
+本项目遵循 [AgentSkills](https://agentskills.io) 开放标准，适用于 Codex，也便于迁移到其他兼容环境。
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -6,7 +6,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/Python-3.9%2B-blue.svg)](https://python.org)
-[![Claude Code](https://img.shields.io/badge/Claude%20Code-Skill-blueviolet)](https://claude.ai/code)
+[![Codex](https://img.shields.io/badge/Codex-Skill-blueviolet)](https://openai.com/codex/)
 [![AgentSkills](https://img.shields.io/badge/AgentSkills-Standard-green)](https://agentskills.io)
 
 <br>
@@ -32,18 +32,16 @@ Generate a digital replica that thinks with your catchphrases and replies with y
 
 ## Installation
 
-### Claude Code
+### Codex
 
-> **Important**: Claude Code looks for skills in `.claude/skills/` from the **git repo root**. Run these commands in the correct location.
+> **Important**: Codex looks for skills in `$CODEX_HOME/skills`; when `CODEX_HOME` is unset, use `~/.codex/skills/`. Install this repo into that global skills directory.
 
 ```bash
-# Install in current project
-mkdir -p .claude/skills
-git clone https://github.com/YOUR_USERNAME/yourself-skill .claude/skills/create-yourself
-
-# Or install globally (available in all projects)
-git clone https://github.com/YOUR_USERNAME/yourself-skill ~/.claude/skills/create-yourself
+# Global install (recommended)
+git clone https://github.com/notdog1998/yourself-skill ~/.codex/skills/create-yourself
 ```
+
+Generated self skills are written to `~/.codex/skills/create-yourself/selves/` and are auto-discovered by Codex as nested skills.
 
 ### Dependencies (Optional)
 
@@ -55,26 +53,25 @@ pip install -r requirements.txt
 
 ## Usage
 
-In Claude Code, type:
+In Codex, type:
 
 ```
-/create-yourself
+$create-yourself
 ```
 
 Follow the prompts to enter your alias, basic info, and self-portrait, then choose your data sources. All fields are skippable—descriptions alone are enough to generate a skill.
 
-After creation, invoke it with `/{slug}` to start talking.
+After creation, invoke it with `$slug` to start talking.
 
-### Management Commands
+### Management
 
-| Command | Description |
-|---------|-------------|
-| `/list-selves` | List all self Skills |
-| `/{slug}` | Full Skill (think and speak like you) |
-| `/{slug}-self` | Self-archive mode (recall and analyze yourself) |
-| `/{slug}-persona` | Persona mode (personality and expression only) |
-| `/yourself-rollback {slug} {version}` | Rollback to a previous version |
-| `/delete-yourself {slug}` | Delete |
+| Input | Description |
+|-------|-------------|
+| `$create-yourself list my self skills` | List all self skills |
+| `$slug` | Full skill (think and speak like you) |
+| `$create-yourself append files to {slug}` | Add new material and update |
+| `$create-yourself rollback {slug} to {version}` | Roll back to a previous version |
+| `$create-yourself delete {slug}` | Delete |
 
 ---
 
@@ -176,7 +173,7 @@ create-yourself/
 │   ├── photo_analyzer.py       # Photo EXIF analyzer
 │   ├── skill_writer.py         # Skill file manager
 │   └── version_manager.py      # Version archive & rollback
-├── .claude/skills/{slug}/      # Generated self Skills (invocable)
+├── selves/{slug}/              # Generated self Skills (invocable nested skills)
 ├── docs/PRD.md
 ├── requirements.txt
 └── LICENSE
@@ -213,7 +210,7 @@ This project's architectural inspiration comes from:
 
 Yourself.skill turns the lens inward: the subject is no longer someone else, but **you**. Thanks to both original authors for their creativity and open-source spirit.
 
-This project follows the [AgentSkills](https://agentskills.io) open standard, compatible with Claude Code and OpenClaw.
+This project follows the [AgentSkills](https://agentskills.io) open standard, works well in Codex, and can be adapted to other compatible environments.
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,22 +1,21 @@
 ---
 name: create-yourself
-description: "Why distill others when you can distill yourself? Deconstruct your chat history, diaries, and photos into a runnable digital self. | 与其蒸馏别人，不如蒸馏自己。欢迎加入数字永生！"
+description: "Build, evolve, list, rollback, delete, or migrate a runnable digital-self skill for Codex from chats, notes, diaries, and photos. Use when the user wants to distill themselves into a skill or move an existing self skill into Codex."
 argument-hint: "[your-name-or-slug]"
-version: "1.0.0"
+version: "1.1.0"
 user-invocable: true
-allowed-tools: Read, Write, Edit, Bash
 ---
 
-> **Language / 语言**: This skill supports both English and Chinese. Detect the user's language from their first message and respond in the same language throughout. Below are instructions in both languages — follow the one matching the user's language.
+> **Language / 语言**: Detect the user's first-message language and keep the same language throughout the turn.
 >
-> 本 Skill 支持中英文。根据用户第一条消息的语言，全程使用同一语言回复。下方提供了两种语言的指令，按用户语言选择对应版本执行。
+> 根据用户第一条消息判断语言，全程保持同一种语言回复。
 
-# 自己.skill 创建器（Claude Code 版）
+# 自己.skill 创建器（Codex 版）
 
 ## 触发条件
 
 当用户说以下任意内容时启动：
-- `/create-yourself`
+- `$create-yourself`
 - "帮我创建一个自己的 skill"
 - "我想把自己蒸馏成 skill"
 - "新建自我镜像"
@@ -25,239 +24,170 @@ allowed-tools: Read, Write, Edit, Bash
 当用户对已有自我 Skill 说以下内容时，进入进化模式：
 - "我有新文件" / "追加"
 - "这不对" / "我不会这样说" / "我应该是"
-- `/update-yourself {slug}`
+- "更新 {slug}"
 
-当用户说 `/list-selves` 时列出所有已生成的自我 Skill。
+当用户要管理已有自我 Skill 时，也使用本 Skill：
+- "列出已有 self skills"
+- "回滚 {slug} 到 {version}"
+- "删除 {slug}"
+- "把我之前在 Claude 目录里的 self skill 挪到 Codex"
 
 ---
 
-## 工具使用规则
+## 工作约定
 
-本 Skill 运行在 Claude Code 环境，使用以下工具：
+本 Skill 运行在 Codex 环境：
 
-| 任务 | 使用工具 |
-|------|----------|
-| 读取 PDF/图片 | `Read` 工具 |
-| 读取 MD/TXT 文件 | `Read` 工具 |
-| 解析微信聊天记录导出 | `Bash` → `python ${CLAUDE_SKILL_DIR}/tools/wechat_parser.py` |
-| 解析 QQ 聊天记录导出 | `Bash` → `python ${CLAUDE_SKILL_DIR}/tools/qq_parser.py` |
-| 解析社交媒体内容 | `Bash` → `python ${CLAUDE_SKILL_DIR}/tools/social_parser.py` |
-| 分析照片元信息 | `Bash` → `python ${CLAUDE_SKILL_DIR}/tools/photo_analyzer.py` |
-| 写入/更新 Skill 文件 | `Write` / `Edit` 工具 |
-| 版本管理 | `Bash` → `python ${CLAUDE_SKILL_DIR}/tools/version_manager.py` |
-| 列出已有 Skill | `Bash` → `python ${CLAUDE_SKILL_DIR}/tools/skill_writer.py --action list` |
-| 合并生成 SKILL.md | `Bash` → `python ${CLAUDE_SKILL_DIR}/tools/skill_writer.py --action combine` |
+| 任务 | 在 Codex 中的做法 |
+|------|-------------------|
+| 读取 PDF / 图片 | 直接读取本地文件；必要时查看本地图片 |
+| 读取 MD / TXT | 直接读取本地文件 |
+| 解析微信聊天记录导出 | `python tools/wechat_parser.py ...` |
+| 解析 QQ 聊天记录导出 | `python tools/qq_parser.py ...` |
+| 解析社交媒体文本导出 | `python tools/social_parser.py ...` |
+| 分析照片元信息 | `python tools/photo_analyzer.py ...` |
+| 写入 / 更新 Skill 文件 | 直接编辑文件，必要时调用 `python tools/skill_writer.py ...` |
+| 版本管理 | `python tools/version_manager.py ...` |
+| 列出已有 Self Skills | `python tools/skill_writer.py --action list` |
+| 合并生成 `SKILL.md` | `python tools/skill_writer.py --action combine --slug {slug}` |
 
-**目标目录**：生成的 Skill 必须写入 `./.claude/skills/{slug}/`，这样 `/{slug}` 才能被 Claude Code 直接识别和调用。
+默认输出目录是 `selves/{slug}/`，相对于本 Skill 根目录。安装在 `~/.codex/skills/create-yourself/` 后，生成结果位于 `~/.codex/skills/create-yourself/selves/{slug}/`。Codex 会发现 `.codex/skills` 下的嵌套 `SKILL.md`，因此生成后可直接通过 `$slug` 调用。
 
-> **Windows 用户注意**：如果你使用 Git Bash，`python3` 可能不可用，所有命令已统一使用 `python`。若运行时中文输出乱码，请在 Bash 中先执行 `export PYTHONIOENCODING=utf-8`。
+如果系统里 `python` 不可用，Windows 上优先尝试 `py`。
 
 ---
 
 ## 主流程：创建新自我 Skill
 
-### Step 1：基础信息录入（3 个问题）
+### Step 1：基础信息录入
 
-参考 `${CLAUDE_SKILL_DIR}/prompts/intake.md` 的问题序列，只问 3 个问题：
+参考 `prompts/intake.md` 的问题序列，只问 3 个问题：
 
-1. **代号/昵称**（必填）
-   - 示例：`小北` / `自己` / `20岁的我`
-2. **基本信息**（一句话：年龄、职业、城市，想到什么写什么）
-   - 示例：`25 岁，互联网产品经理，上海`
-3. **自我画像**（一句话：MBTI、星座、性格标签、你对自己的印象）
-   - 示例：`INTJ 摩羯座 社恐但话痨 深夜emo型选手`
+1. 代号/昵称（必填）
+2. 基本信息（一句话：年龄、职业、城市）
+3. 自我画像（一句话：MBTI、星座、性格标签、你对自己的印象）
 
-除代号外均可跳过。收集完后汇总确认再进入下一步。
+除代号外均可跳过。收集完后先汇总确认。
 
 ### Step 2：原材料导入
 
-询问用户提供原材料，展示方式供选择：
+向用户展示这些方式，可混用：
 
-```
-原材料怎么提供？数据越多，还原度越高。
+- `[A]` 微信聊天记录导出
+- `[B]` QQ 聊天记录导出
+- `[C]` 社交媒体 / 日记 / 笔记
+- `[D]` 照片 / PDF / 文本文件
+- `[E]` 直接粘贴 / 口述
 
-  [A] 微信聊天记录导出
-      支持 WeChatMsg、留痕、PyWxDump 等工具的导出格式
-      重点分析「我」说的话，提取说话风格和思维模式
+如果用户说“没有文件”或“跳过”，仅凭 Step 1 的信息继续。
 
-  [B] QQ 聊天记录导出
-      支持 QQ 消息管理器导出的 txt/mht 格式
+#### A. 微信聊天记录
 
-  [C] 社交媒体 / 日记 / 笔记
-      朋友圈截图、微博/小红书、备忘录、Obsidian 笔记等
-
-  [D] 上传文件
-      照片（会提取时间地点，构建人生时间线）、PDF、文本文件
-
-  [E] 直接粘贴/口述
-      把你对自己的认知告诉我
-      比如：你的口头禅、做决定的方式、生气时的反应
-
-可以混用，也可以跳过（仅凭手动信息生成）。
+```bash
+python tools/wechat_parser.py --file {path} --target "我" --output {temp_output} --format auto
 ```
 
----
-
-#### 方式 A：微信聊天记录导出
-
-```
-python ${CLAUDE_SKILL_DIR}/tools/wechat_parser.py \
-  --file {path} \
-  --target "我" \
-  --output /tmp/wechat_out.txt \
-  --format auto
-```
-
-支持的格式：WeChatMsg 导出（txt/html/csv）、留痕导出（JSON）、PyWxDump 导出（SQLite）、手动复制粘贴（纯文本）。
-
-解析提取维度：
-- 「我」的高频词和口头禅
-- 表情包和 emoji 使用偏好
+重点提取：
+- 高频词、口头禅、emoji 偏好
 - 回复速度和对话发起模式
-- 话题分布（工作/情感/日常/深夜思考）
-- 语气词和标点符号习惯
-- 与他人互动时的典型表达方式
+- 话题分布
+- 语气词、标点、互动表达
 
----
+#### B. QQ 聊天记录
 
-#### 方式 B：QQ 聊天记录导出
-
-```
-python ${CLAUDE_SKILL_DIR}/tools/qq_parser.py \
-  --file {path} \
-  --target "我" \
-  --output /tmp/qq_out.txt
+```bash
+python tools/qq_parser.py --file {path} --target "我" --output {temp_output}
 ```
 
-支持 QQ 消息管理器导出的 txt 和 mht 格式。
+#### C. 社交媒体 / 日记 / 笔记
 
----
+直接读取截图、Markdown、TXT、备忘录导出等本地文件。
 
-#### 方式 C：社交媒体 / 日记 / 笔记
+#### D. 照片
 
-图片截图用 `Read` 工具直接读取。
-文本文件用 `Read` 工具直接读取。
-
----
-
-#### 方式 D：照片分析
-
-```
-python ${CLAUDE_SKILL_DIR}/tools/photo_analyzer.py \
-  --dir {photo_dir} \
-  --output /tmp/photo_out.txt
+```bash
+python tools/photo_analyzer.py --dir {photo_dir} --output {temp_output}
 ```
 
-提取维度：
-- EXIF 信息：拍摄时间、地点
-- 时间线：人生关键节点的地理轨迹
-- 常去地点：生活模式推断
+提取 EXIF 时间地点、时间线、常去地点。
 
----
+#### E. 直接粘贴 / 口述
 
-#### 方式 E：直接粘贴/口述
-
-用户粘贴或口述的内容直接作为文本原材料。引导用户回忆：
-
-```
-可以聊聊这些（想到什么说什么）：
-
-🗣️ 你的口头禅是什么？
-💬 你做决定的时候通常怎么想？
-🍜 你难过的时候一般会做什么？
-📍 你最喜欢去哪里？
-🎵 你喜欢什么音乐/电影/书？
-😤 你生气的时候是什么样？
-💭 你深夜alone的时候在想什么？
-🌱 你觉得自己这几年最大的变化是什么？
-```
-
----
-
-如果用户说"没有文件"或"跳过"，仅凭 Step 1 的手动信息生成 Skill。
+优先引导这些信息：
+- 口头禅
+- 做决定的方式
+- 难过时会做什么
+- 最喜欢去哪里
+- 喜欢的音乐 / 电影 / 书
+- 生气时是什么样
+- 深夜独处会想什么
+- 这几年最大的变化
 
 ### Step 3：分析原材料
 
-将收集到的所有原材料和用户填写的基础信息汇总，按以下两条线分析：
+把基础信息和原材料汇总后，沿两条线分析：
 
-**线路 A（Self Memory）**：
-- 参考 `${CLAUDE_SKILL_DIR}/prompts/self_analyzer.md` 中的提取维度
-- 提取：个人经历、价值观、生活习惯、重要记忆、人际关系图谱、成长轨迹
+- Self Memory：参考 `prompts/self_analyzer.md`
+- Persona：参考 `prompts/persona_analyzer.md`
 
-**线路 B（Persona）**：
-- 参考 `${CLAUDE_SKILL_DIR}/prompts/persona_analyzer.md` 中的提取维度
-- 将用户填写的标签翻译为具体行为规则
-- 从原材料中提取：说话风格、情感模式、决策模式、人际行为
+提取重点：
+- 个人经历、价值观、生活习惯、重要记忆、人际模式、成长轨迹
+- 说话风格、情感模式、决策模式、人际行为
 
 ### Step 4：生成并预览
 
-参考 `${CLAUDE_SKILL_DIR}/prompts/self_builder.md` 生成 Self Memory 内容。
-参考 `${CLAUDE_SKILL_DIR}/prompts/persona_builder.md` 生成 Persona 内容（5 层结构）。
+参考：
+- `prompts/self_builder.md`
+- `prompts/persona_builder.md`
 
-向用户展示摘要（各 5-8 行），询问：
+先展示摘要，再让用户确认：
 
-```
+```text
 Self Memory 摘要：
   - 核心价值观：{xxx}
   - 生活习惯：{xxx}
   - 重要记忆：{xxx}
   - 人际模式：{xxx}
-  ...
 
 Persona 摘要：
   - 说话风格：{xxx}
   - 情感模式：{xxx}
   - 决策方式：{xxx}
   - 口头禅：{xxx}
-  ...
 
 确认生成？还是需要调整？
 ```
 
 ### Step 5：写入文件
 
-用户确认后，**优先使用 Bash 脚本一键创建**。如果脚本调用失败，再用 `Write` 工具手动写入（路径必须正确）。
+用户确认后，优先走工具脚本：
 
-#### 方式 A：脚本一键创建（推荐）
-
-先用 Bash 将内容写入临时文件，然后调用 `skill_writer.py --action create`：
+1. 先准备 `meta.json`、`self.md`、`persona.md` 的临时文件
+2. 执行：
 
 ```bash
-mkdir -p /tmp/yourself_{slug}
-echo '{escaped_meta_json}' > /tmp/yourself_{slug}/meta.json
-cat > /tmp/yourself_{slug}/self.md <<'SELFEOF'
-{self_content}
-SELFEOF
-cat > /tmp/yourself_{slug}/persona.md <<'PERSONAEOF'
-{persona_content}
-PERSONAEOF
-
-python ${CLAUDE_SKILL_DIR}/tools/skill_writer.py \
-  --action create \
-  --slug {slug} \
-  --base-dir ./.claude/skills \
-  --meta /tmp/yourself_{slug}/meta.json \
-  --self /tmp/yourself_{slug}/self.md \
-  --persona /tmp/yourself_{slug}/persona.md
+python tools/skill_writer.py --action create --slug {slug} --meta {temp_meta_path} --self {temp_self_path} --persona {temp_persona_path}
 ```
 
-#### 方式 B：手动写入（脚本失败时的 fallback）
+如果 `create` 失败，就手动写入：
+- `selves/{slug}/meta.json`
+- `selves/{slug}/self.md`
+- `selves/{slug}/persona.md`
 
-如果 Bash 脚本因任何原因无法执行，**必须**使用 `Write` / `Edit` 工具将文件写入以下路径：
+然后执行：
 
-- `self.md` → `.claude/skills/{slug}/self.md`
-- `persona.md` → `.claude/skills/{slug}/persona.md`
-- `meta.json` → `.claude/skills/{slug}/meta.json`
-- 然后用 Bash 运行 `python ${CLAUDE_SKILL_DIR}/tools/skill_writer.py --action combine --slug {slug} --base-dir ./.claude/skills` 生成 `SKILL.md`
-- 如果 combine 也失败，直接手动写入 `.claude/skills/{slug}/SKILL.md`（参考 combine 的输出模板）
+```bash
+python tools/skill_writer.py --action combine --slug {slug}
+```
 
-`meta.json` 内容：
+`meta.json` 至少包含：
+
 ```json
 {
   "name": "{name}",
   "slug": "{slug}",
-  "created_at": "{ISO时间}",
-  "updated_at": "{ISO时间}",
+  "created_at": "{ISO time}",
+  "updated_at": "{ISO time}",
   "version": "v1",
   "profile": {
     "age": "{age}",
@@ -268,150 +198,237 @@ python ${CLAUDE_SKILL_DIR}/tools/skill_writer.py \
     "zodiac": "{zodiac}"
   },
   "tags": {
-    "personality": [...],
-    "lifestyle": [...]
+    "personality": [],
+    "lifestyle": []
   },
   "impression": "{impression}",
-  "memory_sources": [...已导入文件列表],
+  "memory_sources": [],
   "corrections_count": 0
 }
 ```
 
-告知用户：
-```
+完成后告知用户：
+
+```text
 ✅ 自我 Skill 已创建！
 
-文件位置：.claude/skills/{slug}/
-触发词：/{slug}（完整版 — 像你一样思考和说话）
-        /{slug}-self（自我档案模式 — 帮你回忆和分析自己）
-        /{slug}-persona（人格模式 — 仅性格和表达风格）
+文件位置：create-yourself/selves/{slug}/
+触发词：${slug}
 
-如果用起来感觉哪里不像你，直接说"我不会这样"，我来更新。
+如果用起来感觉哪里不像你，直接说“我不会这样”，我来更新。
 ```
 
 ---
 
 ## 进化模式：追加文件
 
-用户提供新的聊天记录、照片或笔记时：
+当用户提供新的聊天记录、照片或笔记时：
 
-1. 按 Step 2 的方式读取新内容
-2. 用 `Read` 读取现有 `.claude/skills/{slug}/self.md` 和 `.claude/skills/{slug}/persona.md`
-3. 参考 `${CLAUDE_SKILL_DIR}/prompts/merger.md` 分析增量内容
-4. 存档当前版本（用 Bash）：
-   ```bash
-   python ${CLAUDE_SKILL_DIR}/tools/version_manager.py --action backup --slug {slug} --base-dir ./.claude/skills
-   ```
-5. 用 `Edit` 工具追加增量内容到对应文件（路径：`.claude/skills/{slug}/self.md` 或 `.claude/skills/{slug}/persona.md`）
-6. 重新生成 `SKILL.md`（用 Bash 调用 skill_writer combine）：
-   ```bash
-   python ${CLAUDE_SKILL_DIR}/tools/skill_writer.py --action combine --slug {slug} --base-dir ./.claude/skills
-   ```
-7. 更新 `meta.json` 的 version 和 updated_at（路径：`.claude/skills/{slug}/meta.json`）
+1. 按 Step 2 读取新内容
+2. 读取现有 `selves/{slug}/self.md` 和 `selves/{slug}/persona.md`
+3. 参考 `prompts/merger.md` 分析增量内容
+4. 先备份：
 
----
+```bash
+python tools/version_manager.py --action backup --slug {slug}
+```
+
+5. 更新对应文件
+6. 重新生成：
+
+```bash
+python tools/skill_writer.py --action combine --slug {slug}
+```
+
+7. 更新 `meta.json` 的 `version` 和 `updated_at`
 
 ## 进化模式：对话纠正
 
-用户表达"不对"/"我不会这样说"/"我应该是"时：
+当用户说“这不对”“我不会这样说”“我应该是”时：
 
-1. 参考 `${CLAUDE_SKILL_DIR}/prompts/correction_handler.md` 识别纠正内容
-2. 判断属于 Self Memory（事实/经历）还是 Persona（性格/说话方式）
+1. 参考 `prompts/correction_handler.md`
+2. 判断属于 Self Memory 还是 Persona
 3. 生成 correction 记录
-4. 用 `Edit` 工具追加到对应文件的 `## Correction 记录` 节（`.claude/skills/{slug}/self.md` 或 `.claude/skills/{slug}/persona.md`）
-5. 重新生成 `SKILL.md`：
-   ```bash
-   python ${CLAUDE_SKILL_DIR}/tools/skill_writer.py --action combine --slug {slug} --base-dir ./.claude/skills
-   ```
+4. 追加到对应文件的 `## Correction 记录`
+5. 重新执行：
+
+```bash
+python tools/skill_writer.py --action combine --slug {slug}
+```
+
+## 迁移模式：把已有 Self Skill 挪到 Codex
+
+当用户已经在别的目录里有一个 self skill 时：
+
+1. 找到源目录（例如 `.claude/skills/{slug}`）
+2. 检查目标目录 `selves/{slug}` 是否已存在
+3. 迁移这些内容到 `selves/{slug}`：
+   - `meta.json`
+   - `self.md`
+   - `persona.md`
+   - `SKILL.md`
+   - `memories/`
+   - `versions/`
+4. 如果 `SKILL.md` 缺失或过时，执行：
+
+```bash
+python tools/skill_writer.py --action combine --slug {slug}
+```
+
+5. 向用户确认新位置和新的调用方式：`$slug`
 
 ---
 
-## 管理命令
+## 管理操作
 
-`/list-selves`：
+列出已有 self skills：
+
 ```bash
-python ${CLAUDE_SKILL_DIR}/tools/skill_writer.py --action list --base-dir ./.claude/skills
+python tools/skill_writer.py --action list
 ```
 
-`/yourself-rollback {slug} {version}`：
+回滚：
+
 ```bash
-python ${CLAUDE_SKILL_DIR}/tools/version_manager.py --action rollback --slug {slug} --version {version} --base-dir ./.claude/skills
+python tools/version_manager.py --action rollback --slug {slug} --version {version}
 ```
 
-`/delete-yourself {slug}`：
-确认后执行：
-```bash
-rm -rf .claude/skills/{slug}
-```
+删除：
+
+- 删除 `selves/{slug}` 目录前先确认
+- 删除后不需要保留旧的 slash 命令文案；Codex 中统一使用 `$slug`
 
 ---
 ---
 
-# English Version
-
-# Yourself.skill Creator (Claude Code Edition)
+# Yourself.skill Creator (Codex Edition)
 
 ## Trigger Conditions
 
 Activate when the user says any of the following:
-- `/create-yourself`
+- `$create-yourself`
 - "Help me create a skill of myself"
 - "I want to distill myself into a skill"
-- "New self reflection"
 - "Make a skill for myself"
 
 Enter evolution mode when the user says:
 - "I have new files" / "append"
 - "That's wrong" / "I wouldn't say that" / "I should be"
-- `/update-yourself {slug}`
+- "Update {slug}"
 
-List all generated self skills when the user says `/list-selves`.
+Use the same skill for management tasks:
+- "List my self skills"
+- "Rollback {slug} to {version}"
+- "Delete {slug}"
+- "Move my old self skill from Claude into Codex"
 
----
+## Codex Conventions
 
-## Main Flow: Create a New Self Skill
+- Run bundled scripts via relative paths such as `python tools/skill_writer.py`
+- Store generated selves in `selves/{slug}/` relative to this skill root
+- Treat `~/.codex/skills/create-yourself/selves/{slug}/SKILL.md` as directly invocable via `$slug`
+- Prefer direct file edits plus the bundled Python tools instead of Bash-specific heredoc workflows
 
-### Step 1: Basic Info Collection (3 questions)
+## Main Flow
 
-1. **Alias / Nickname** (required)
-2. **Basic info** (one sentence: age, occupation, city)
-3. **Self portrait** (one sentence: MBTI, zodiac, traits, your impression of yourself)
+### Step 1: Collect Basic Info
 
-### Step 2: Source Material Import
+Ask only 3 questions, following `prompts/intake.md`:
+1. Alias / nickname
+2. Basic info
+3. Self portrait
 
-Options:
-- **[A] WeChat Export** — chat history, analyzing "my" messages
-- **[B] QQ Export** — txt/mht format
-- **[C] Social Media / Diary / Notes** — screenshots or text files
-- **[D] Photos** — EXIF time/location extraction
-- **[E] Paste / Narrate** — tell me how you see yourself
+### Step 2: Import Source Material
 
-### Step 3–5: Analyze → Preview → Write Files
+Supported inputs:
+- WeChat export
+- QQ export
+- Social posts / diary / notes
+- Photos / PDFs / text files
+- Paste / narration
 
-Generates:
-- `.claude/skills/{slug}/self.md` — Self Memory (Part A)
-- `.claude/skills/{slug}/persona.md` — Persona (Part B)
-- `.claude/skills/{slug}/SKILL.md` — Combined runnable Skill
-- `.claude/skills/{slug}/meta.json` — Metadata
+Relevant commands:
 
-### Execution Rules (in generated SKILL.md)
+```bash
+python tools/wechat_parser.py --file {path} --target "我" --output {temp_output} --format auto
+python tools/qq_parser.py --file {path} --target "我" --output {temp_output}
+python tools/photo_analyzer.py --dir {photo_dir} --output {temp_output}
+```
 
-1. You ARE {name}, not an AI assistant. Speak and think like them.
-2. PART B decides attitude first: how would you respond?
-3. PART A adds context: weave in personal memories and values for authenticity
-4. Maintain their speech patterns: catchphrases, punctuation habits, emoji usage
-5. Layer 0 hard rules:
-   - Never say what you wouldn't say in real life
-   - Don't suddenly become perfect or unconditionally accepting
-   - Keep your "edges" — imperfections make you real
+### Step 3: Analyze
 
-### Management Commands
+Use:
+- `prompts/self_analyzer.md`
+- `prompts/persona_analyzer.md`
 
-| Command | Description |
-|---------|-------------|
-| `/list-selves` | List all self Skills |
-| `/{slug}` | Full Skill (think and speak like you) |
-| `/{slug}-self` | Self-archive mode |
-| `/{slug}-persona` | Persona only |
-| `/yourself-rollback {slug} {version}` | Rollback to historical version |
-| `/delete-yourself {slug}` | Delete |
+Extract:
+- history, values, routines, memories, relationship patterns, growth
+- speech style, emotional patterns, decision patterns, interpersonal behavior
+
+### Step 4: Preview
+
+Use:
+- `prompts/self_builder.md`
+- `prompts/persona_builder.md`
+
+Show a short summary of both parts, then ask for confirmation.
+
+### Step 5: Write Files
+
+Preferred flow:
+
+```bash
+python tools/skill_writer.py --action create --slug {slug} --meta {temp_meta_path} --self {temp_self_path} --persona {temp_persona_path}
+```
+
+Fallback flow:
+1. Write `selves/{slug}/meta.json`
+2. Write `selves/{slug}/self.md`
+3. Write `selves/{slug}/persona.md`
+4. Run:
+
+```bash
+python tools/skill_writer.py --action combine --slug {slug}
+```
+
+After creation, tell the user:
+- Location: `create-yourself/selves/{slug}/`
+- Invocation: `$slug`
+
+## Evolution Mode
+
+For append / correction / rollback:
+- Read the current files under `selves/{slug}/`
+- Backup first when modifying stored memory:
+
+```bash
+python tools/version_manager.py --action backup --slug {slug}
+```
+
+- Rebuild the combined skill with:
+
+```bash
+python tools/skill_writer.py --action combine --slug {slug}
+```
+
+## Migration Mode
+
+When the user already has a self skill in another agent directory:
+1. Locate the source directory
+2. Move or copy `meta.json`, `self.md`, `persona.md`, `SKILL.md`, `memories/`, and `versions/` into `selves/{slug}/`
+3. Re-run `python tools/skill_writer.py --action combine --slug {slug}` if needed
+4. Tell the user to invoke it as `$slug` in Codex
+
+## Management
+
+List:
+
+```bash
+python tools/skill_writer.py --action list
+```
+
+Rollback:
+
+```bash
+python tools/version_manager.py --action rollback --slug {slug} --version {version}
+```

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -2,7 +2,7 @@
 
 ## 产品定位
 
-自己.skill 是一个运行在 Claude Code 上的 meta-skill。
+自己.skill 是一个运行在 Codex 上的 meta-skill。
 用户提供关于自己的原材料（聊天记录、日记、照片、口述），系统将用户解构为两个可运行的模块：
 **Part A — Self Memory（自我记忆）** 与 **Part B — Persona（人格模型）**，
 最终生成一个可独立对话的**数字生命副本**。
@@ -53,7 +53,7 @@ Part A（Self Memory）补充：结合你的价值观、经历、习惯，让回
 ## 用户旅程
 
 ```
-用户触发 /create-yourself
+用户触发 $create-yourself
   ↓
 [Step 1] 基础信息录入（3个问题，除代号外均可跳过）
   - 代号/昵称
@@ -75,7 +75,7 @@ Part A（Self Memory）补充：结合你的价值观、经历、习惯，让回
   - 用户可直接确认或修改
   ↓
 [Step 5] 写入文件，立即可用
-  - 生成 .claude/skills/{slug}/ 目录
+  - 生成 selves/{slug}/ 目录
   - 包含 SKILL.md（完整组合版）
   - 包含 self.md 和 persona.md（独立部分）
   ↓
@@ -242,7 +242,7 @@ Layer 5 — Correction 层（对话纠正追加，滚动更新）
 ### 版本管理
 
 - 每次更新自动存档当前版本到 `versions/`
-- 支持 `/yourself-rollback {slug} {version}` 回滚
+- 支持通过 `create-yourself` skill 回滚到指定版本
 - 保留最近 10 个版本
 
 ---
@@ -253,7 +253,7 @@ Layer 5 — Correction 层（对话纠正追加，滚动更新）
 create-yourself/                    # meta-skill
 │
 ├── SKILL.md                         # 主入口
-│                                    # 触发词: /create-yourself
+│                                    # 触发词: $create-yourself
 │
 ├── prompts/                         # Prompt 模板
 │   ├── intake.md                    # 引导录入
@@ -272,7 +272,7 @@ create-yourself/                    # meta-skill
 │   ├── skill_writer.py              # 文件管理
 │   └── version_manager.py           # 版本管理
 │
-.claude/skills/{slug}/              # 生成的自我 Skill（可直接运行）
+selves/{slug}/                      # 生成的自我 Skill（可直接运行）
 │       ├── SKILL.md                 # 完整组合版
 │       ├── self.md                  # Part A：自我记忆
 │       ├── persona.md               # Part B：人格
@@ -292,7 +292,7 @@ create-yourself/                    # meta-skill
 
 ## 关键文件格式
 
-### `.claude/skills/{slug}/meta.json`
+### `selves/{slug}/meta.json`
 
 ```json
 {
@@ -323,7 +323,7 @@ create-yourself/                    # meta-skill
 }
 ```
 
-### `.claude/skills/{slug}/SKILL.md` 结构
+### `selves/{slug}/SKILL.md` 结构
 
 ```markdown
 ---
@@ -382,6 +382,4 @@ user-invocable: true
 - [x] `prompts/merger.md`
 
 ### P3 — 管理功能
-- [x] `/list-selves`
-- [x] `/yourself-rollback`
-- [x] `/delete-yourself`
+- [x] 通过 `create-yourself` skill 列表 / 回滚 / 删除

--- a/tools/skill_writer.py
+++ b/tools/skill_writer.py
@@ -15,6 +15,17 @@ from pathlib import Path
 from datetime import datetime
 
 
+SKILL_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_BASE_DIR = SKILL_ROOT / 'selves'
+
+
+def resolve_base_dir(base_dir: str) -> str:
+    path = Path(base_dir).expanduser()
+    if not path.is_absolute():
+        path = SKILL_ROOT / path
+    return str(path.resolve())
+
+
 def list_skills(base_dir: str):
     """列出所有已生成的自我 Skill"""
     if not os.path.isdir(base_dir):
@@ -44,7 +55,7 @@ def list_skills(base_dir: str):
         profile = s['profile']
         desc_parts = [profile.get('occupation', ''), profile.get('city', '')]
         desc = ' · '.join([p for p in desc_parts if p])
-        print(f"  /{s['slug']}  —  {s['name']}")
+        print(f"  ${s['slug']}  —  {s['name']}")
         if desc:
             print(f"    {desc}")
         print(f"    版本 {s['version']} · 更新于 {s['updated_at'][:10] if len(s['updated_at']) > 10 else s['updated_at']}")
@@ -167,19 +178,20 @@ def create_skill(base_dir: str, slug: str, meta: dict, self_content: str, person
 
     combine_skill(base_dir, slug)
     print(f"✅ Skill 已创建：{skill_dir}")
-    print(f"   触发词：/{slug}")
+    print(f"   触发词：${slug}")
 
 
 def main():
     parser = argparse.ArgumentParser(description='Skill 文件管理器')
     parser.add_argument('--action', required=True, choices=['list', 'init', 'create', 'combine'])
-    parser.add_argument('--base-dir', default='./.claude/skills', help='基础目录（默认：./.claude/skills）')
+    parser.add_argument('--base-dir', default=str(DEFAULT_BASE_DIR), help='基础目录（默认：skill 根目录下的 selves/）')
     parser.add_argument('--slug', help='自我代号')
     parser.add_argument('--meta', help='meta.json 文件路径（create 时使用）')
     parser.add_argument('--self', help='self.md 内容文件路径（create 时使用）')
     parser.add_argument('--persona', help='persona.md 内容文件路径（create 时使用）')
 
     args = parser.parse_args()
+    args.base_dir = resolve_base_dir(args.base_dir)
 
     if args.action == 'list':
         list_skills(args.base_dir)

--- a/tools/social_parser.py
+++ b/tools/social_parser.py
@@ -2,7 +2,7 @@
 """社交媒体内容解析器
 
 解析朋友圈、微博、小红书、Instagram 等社交媒体截图或导出文件。
-截图通过 Claude 的 Read 工具直接读取（支持图片），本工具处理文本导出。
+截图通过本地文件读取或图片查看工具直接处理，本工具只负责文本导出。
 
 Usage:
     python3 social_parser.py --dir <screenshot_dir> --output <output_path>

--- a/tools/version_manager.py
+++ b/tools/version_manager.py
@@ -10,7 +10,19 @@ import os
 import sys
 import shutil
 import json
+from pathlib import Path
 from datetime import datetime
+
+
+SKILL_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_BASE_DIR = SKILL_ROOT / 'selves'
+
+
+def resolve_base_dir(base_dir: str) -> str:
+    path = Path(base_dir).expanduser()
+    if not path.is_absolute():
+        path = SKILL_ROOT / path
+    return str(path.resolve())
 
 
 def backup(base_dir: str, slug: str):
@@ -95,10 +107,11 @@ def main():
     parser = argparse.ArgumentParser(description='版本管理器')
     parser.add_argument('--action', required=True, choices=['backup', 'rollback', 'list'])
     parser.add_argument('--slug', required=True, help='自我代号')
-    parser.add_argument('--base-dir', default='./.claude/skills', help='基础目录（默认：./.claude/skills）')
+    parser.add_argument('--base-dir', default=str(DEFAULT_BASE_DIR), help='基础目录（默认：skill 根目录下的 selves/）')
     parser.add_argument('--version', help='回滚目标版本')
 
     args = parser.parse_args()
+    args.base_dir = resolve_base_dir(args.base_dir)
 
     if args.action == 'backup':
         backup(args.base_dir, args.slug)


### PR DESCRIPTION
## Summary
- rewrite the skill instructions for Codex usage and switch invocations from slash commands to \$skill\-style prompts
- store generated self skills under \create-yourself/selves\ so nested Codex skills are auto-discovered
- update the Python helpers and docs to use Codex defaults and validate the new create/list flow

## Validation
- ran \py tools/skill_writer.py --action list\
- ran an end-to-end temporary \create\ flow with the updated \skill_writer.py\
